### PR TITLE
Additional config file

### DIFF
--- a/src/mangonetwork/raw/process_raw_images.py
+++ b/src/mangonetwork/raw/process_raw_images.py
@@ -602,6 +602,9 @@ def parse_args():
         "-c", "--config", metavar="FILE", help="Alternate configuration file"
     )
     parser.add_argument(
+        "-a", "--addconfig", metavar="FILE", nargs='*', help="Additional configuration files"
+    )
+    parser.add_argument(
         "-f",
         "--filelist",
         metavar="FILE",
@@ -701,15 +704,19 @@ def main():
     if args.config:
         logging.debug("Alternate configuration file: %s", args.config)
         if os.path.exists(args.config):
-            config_file = args.config
+            config_files = [args.config]
         else:
             logging.error("Config file not found")
             sys.exit(1)
     else:
-        config_file = find_config(inputs[0])
+        default_config = find_config(inputs[0])
+        config_files = [default_config]
+
+    if args.addconfig:
+        config_files.extend(args.addconfig)
 
     config = configparser.ConfigParser()
-    config.read(config_file)
+    config.read(config_files)
 
     # Process images
     processor = ImageProcessor(config)

--- a/src/mangonetwork/raw/quicklook_movies.py
+++ b/src/mangonetwork/raw/quicklook_movies.py
@@ -210,6 +210,9 @@ def parse_args():
         "-c", "--config", metavar="FILE", help="Alternate configuration file"
     )
     parser.add_argument(
+        "-a", "--addconfig", metavar="FILE", nargs='*', help="Additional configuration files"
+    )
+    parser.add_argument(
         "-f",
         "--filelist",
         metavar="FILE",
@@ -288,15 +291,19 @@ def main():
     if args.config:
         logging.debug("Alternate configuration file: %s", args.config)
         if os.path.exists(args.config):
-            config_file = args.config
+            config_files = [args.config]
         else:
             logging.error("Config file not found")
             sys.exit(1)
     else:
-        config_file = find_config(inputs[0])
+        default_config = find_config(inputs[0])
+        config_files = [default_config]
+
+    if args.addconfig:
+        config_files.extend(args.addconfig)
 
     config = configparser.ConfigParser()
-    config.read(config_file)
+    config.read(config_files)
 
     # Generate quicklook movie
     movie = QuickLook(config)


### PR DESCRIPTION
Add option to provide a list of additional config files at the command line to overwrite options in the main config.  This is used with the `-a` flag.